### PR TITLE
根据v5版本现有文档添加配置

### DIFF
--- a/V5-Shadowsocks-TCP/client.json
+++ b/V5-Shadowsocks-TCP/client.json
@@ -1,0 +1,45 @@
+{
+    "access": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "error": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "inbounds": [
+        {
+            "listen": "127.0.0.1",
+            "port": "10808",
+            "protocol": "socks",
+            "settings": {
+                "udpEnabled": true,
+                "address": "127.0.0.1"
+            }
+        },
+        {
+            "listen": "127.0.0.1",
+            "port": "10809",
+            "protocol": "http"
+        }
+    ],
+    "outbounds": [
+        {
+            "protocol": "shadowsocks",
+            "settings": {
+                "address": "{{ host }}",
+                "port": 1234,
+                "method": "chacha20-ietf-poly1305",
+                "password": "{{ password}}"
+            },
+            "streamSettings": {
+                "transport": "tcp"
+            },
+            "tag": "proxy"
+        },
+        {
+            "protocol": "freedom",
+            "tag": "direct"
+        }
+    ]
+}

--- a/V5-Shadowsocks-TCP/server.json
+++ b/V5-Shadowsocks-TCP/server.json
@@ -1,0 +1,34 @@
+{
+    "access": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "error": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "inbounds": [
+        {
+            "listen": "0.0.0.0",
+            "port": 1234,
+            "protocol": "shadowsocks",
+            "settings": {
+                "method": "chacha20-ietf-poly1305",
+                "password": "{{ password }}"
+            },
+            "streamSettings": {
+                "transport": "tcp"
+            }
+        }
+    ],
+    "outbounds": [
+        {
+            "protocol": "freedom",
+            "tag": "direct"
+        },
+        {
+            "protocol": "blackhole",
+            "tag": "block"
+        }
+    ]
+}

--- a/V5-Shadowsocks-Websocket-Web-TLS/Domainsocket-or-Redirect-Approach/README-CN.md
+++ b/V5-Shadowsocks-Websocket-Web-TLS/Domainsocket-or-Redirect-Approach/README-CN.md
@@ -1,0 +1,59 @@
+# 这是一个使用 V2Ray 作为 ss + v2ray plugin 服务端的示例
+
+> 完整的设置还需要一个 web 服务器解密 TLS 后,将请求转发给位于 127.0.0.1:10000 的 v2ray。由于 [https://guide.v2fly.org/advanced/wss_and_web.html#%E9%85%8D%E7%BD%AE](https://guide.v2fly.org/advanced/wss_and_web.html#%E9%85%8D%E7%BD%AE) 已经有了服务器的设置这里不再赘述，可以按需参考白话文教程里的 web 服务器设置。
+
+config_server_redirect.json 和 config_server_domainsocket.json 选其一。
+
+如果使用 domain socket 需要修改`/etc/systemd/system/v2ray.service`。否则由于 fhs 脚本使用的 nobody 用户的权限不够，无法在/var/run 里新建文件夹`ss-loop`而导致启动失败。
+
+> 如果使用 fhs 脚本更新版本的话，会覆盖掉 service 文件，所以更新版本后需要重复下面的操作。
+
+修改文件`/etc/systemd/system/v2rary.service`，在`[Service]`部分添加下面一行：
+
+```properties
+RuntimeDirectory=ss-loop
+```
+
+`ss-loop`对应 config.json 里的`dsSettings`部分的 path 里的文件夹`/var/run/ss-loop`
+
+修改完成后需要执行
+
+```shell
+systemctl disable v2ray.service
+systemctl enable v2ray.service
+```
+
+最后重启下 v2ray 进程
+
+```shell
+systemctl restart v2ray
+```
+
+## 客户端配置示意
+
+你应该按照服务端的设置修改对应的参数
+
+### shadowsocks windows 客户端关键部分示例如下
+
+```properties
+Server_IP: example.com or your server ip
+Server_Port: 443
+Password: ifYouWantToKeepYourPassphraseSafeChangeThis!!
+Encryption: chacha20-ietf-poly1305
+Plugin_Program: pathToYourV2ray-plugin_windows_arch.exe
+Plugin_Options: tls;mode=websocket;path=/michi;host=example.com
+```
+
+### shadowsocks Android plugin 关键部分示例如下
+
+需安装 shadowsocks 和 v2ray plugin，并搭配一同使用
+
+```properties
+Plugin: v2ray
+Configuration:
+    Transport_mode: websocket-tls
+    Hostname: example.com
+    Path: /michi
+    Concurrent_connections: 1
+    Certificate_for_TLS_verification: Not set
+```

--- a/V5-Shadowsocks-Websocket-Web-TLS/Domainsocket-or-Redirect-Approach/README.md
+++ b/V5-Shadowsocks-Websocket-Web-TLS/Domainsocket-or-Redirect-Approach/README.md
@@ -1,0 +1,63 @@
+# This is the server config.json example to utilizing V2ray as the server for Shadowsocks + V2Ray Plugin
+
+> The complete setup also requires a web server to handle the TLS and proxy pass the deciphered request to the backend v2ray server at 127.0.0.1:10000.
+> You can find the web server config example at [https://guide.v2fly.org/en_US/advanced/wss_and_web.html#server-side-configuration](https://guide.v2fly.org/en_US/advanced/wss_and_web.html#server-side-configuration).
+
+中文用户请看[这里](./README-CN.md)。
+
+Choose one of the server config `config_server_redirect.json` and `config_server_domainsocket.json`.
+
+If you choose to use `config_server_domainsocket.json`, the following extra steps are required. Since the default service file created by [`fhs-release.sh`](https://github.com/v2fly/fhs-install-v2ray) is using nobody as the runtime user, this user does not have the permission to create the `ss-loop` folder in `/var/run`.
+
+> You shall repeat the following steps after using [`fhs-release.sh`](https://github.com/v2fly/fhs-install-v2ray) scripts to upgrade v2ray-core versions each time. Since this script will always override the v2ray.service file.
+
+Use your prefered editor to modify the systemd service file at `/etc/systemd/system/v2ray.service`.\
+Add the following line to the block starting with `[Service]`.
+
+```properties
+RuntimeDirectory=ss-loop
+```
+
+`ss-loop` corresponds to the `/var/run/ss-loop` folder in the `dsSettings` inside config_server_domainsocket.json.
+
+Execute the following commands to re-enable the v2ray.service.
+
+```shell
+systemctl disable v2ray.service
+systemctl enable v2ray.service
+```
+
+Then restart the v2ray service.
+
+```shell
+systemctl restart v2ray
+```
+
+## Client configuration examples
+
+> You should change the following configurations according to your server configs.
+
+### shadowsocks windows client configuration examples
+
+```properties
+Server_IP: example.com or your server IP
+Server_Port: 443
+Password: ifYouWantToKeepYourPassphraseSafeChangeThis!!
+Encryption: chacha20-ietf-poly1305
+Plugin_Program: pathToYourV2ray-plugin_windows_arch.exe
+Plugin_Options: tls;mode=websocket;path=/michi;host=example.com
+```
+
+### shadowsocks Android plugin configuration examples
+
+> Both the shadowsocks android and the V2Ray plugin android are mandatory, they are available on Google Play Store.
+
+```properties
+Plugin: v2ray
+Configuration:
+    Transport_mode: websocket-tls
+    Hostname: example.com
+    Path: /michi
+    Concurrent_connections: 1
+    Certificate_for_TLS_verification: Not set
+```

--- a/V5-Shadowsocks-Websocket-Web-TLS/Domainsocket-or-Redirect-Approach/config_server_domainsocket.json
+++ b/V5-Shadowsocks-Websocket-Web-TLS/Domainsocket-or-Redirect-Approach/config_server_domainsocket.json
@@ -1,0 +1,81 @@
+{
+    "access": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "error": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "routing": {
+        "domainStrategy": "AsIs",
+        "rules": [
+            {
+                "type": "field",
+                "inboundTag": "wsdoko",
+                "outboundTag": "ssmux"
+            }
+        ]
+    },
+    "inbounds": [
+        {
+            "port": 10000,
+            "listen": "127.0.0.1",
+            "protocol": "dokodemo-door",
+            "tag": "wsdoko",
+            "settings": {
+                "address": "v1.mux.cool",
+                "followRedirect": false,
+                "network": "tcp, udp"
+            },
+            "sniffing": {
+                "enabled": true,
+                "destOverride": [
+                    "http",
+                    "tls"
+                ]
+            },
+            "streamSettings": {
+                "transport": "ws",
+                "transportSettings": {
+                    "path": "/path"
+                }
+            }
+        },
+        {
+            "port": 9000,
+            "protocol": "shadowsocks",
+            "settings": {
+                "method": "chacha20-ietf-poly1305",
+                "ota": false,
+                "password": "ifYouWantToKeepYourPassphraseSafeChangeThis!!",
+                "network": "tcp,udp"
+            },
+            "streamSettings": {
+                "transport": "domainsocket"
+            }
+        }
+    ],
+    "outbounds": [
+        {
+            "protocol": "freedom",
+            "settings": {},
+            "tag": "direct"
+        },
+        {
+            "protocol": "blackhole",
+            "settings": {},
+            "tag": "blocked"
+        },
+        {
+            "protocol": "freedom",
+            "tag": "ssmux",
+            "streamSettings": {
+                "network": "domainsocket"
+            }
+        }
+    ],
+    "dsSettings": {
+        "path": "/var/run/ss-loop/ss-loop.sock"
+    }
+}

--- a/V5-Shadowsocks-Websocket-Web-TLS/Domainsocket-or-Redirect-Approach/config_server_redirect.json
+++ b/V5-Shadowsocks-Websocket-Web-TLS/Domainsocket-or-Redirect-Approach/config_server_redirect.json
@@ -1,0 +1,74 @@
+{
+    "access": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "error": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "router": {
+        "domainStrategy": "AsIs",
+        "rule": [
+            {
+                "inboundTag": "wsdoko",
+                "tag": "ssredirect"
+            }
+        ]
+    },
+    "inbounds": [
+        {
+            "port": 10000,
+            "listen": "127.0.0.1",
+            "protocol": "dokodemo-door",
+            "tag": "wsdoko",
+            "settings": {
+                "address": "v1.mux.cool",
+                "followRedirect": false,
+                "network": "tcp, udp"
+            },
+            "sniffing": {
+                "enabled": true,
+                "destOverride": [
+                    "http",
+                    "tls"
+                ]
+            },
+            "streamSettings": {
+                "transport": "ws",
+                "transportSettings": {
+                    "path": "/path"
+                }
+            }
+        },
+        {
+            "port": 9000,
+            "protocol": "shadowsocks",
+            "settings": {
+                "method": "chacha20-ietf-poly1305",
+                "ota": false,
+                "password": "ifYouWantToKeepYourPassphraseSafeChangeThis!!",
+                "network": "tcp,udp"
+            }
+        }
+    ],
+    "outbounds": [
+        {
+            "protocol": "freedom",
+            "settings": {},
+            "tag": "direct"
+        },
+        {
+            "protocol": "blackhole",
+            "settings": {},
+            "tag": "blocked"
+        },
+        {
+            "protocol": "freedom",
+            "tag": "ssredirect",
+            "settings": {
+                "redirect": "127.0.0.1:9000"
+            }
+        }
+    ]
+}

--- a/V5-Shadowsocks-Websocket-Web-TLS/README-CN.md
+++ b/V5-Shadowsocks-Websocket-Web-TLS/README-CN.md
@@ -1,0 +1,35 @@
+# 这个例子同样适用于 Shadowsocks 客户端+V2Ray-Plugins
+
+> 完整的设置还需要一个 web 服务器解密 TLS 后,将请求转发给监听在 127.0.0.1:10000 的 v2ray。由于 [https://guide.v2fly.org/advanced/wss_and_web.html#%E9%85%8D%E7%BD%AE](https://guide.v2fly.org/advanced/wss_and_web.html#%E9%85%8D%E7%BD%AE) 已经有了服务器的设置这里不再赘述，可以按需参考白话文教程里的 web 服务器设置。
+
+## 客户端配置示意
+
+你应该按照服务端的设置修改对应的参数。
+
+### shadowsocks windows 客户端关键部分示例如下
+
+> 必须设置 mux=0，否则无法正常连接服务器。如果需要使用 mux 可以参考本文件夹里的[Domainsocket or Redirect Approach](./Domainsocket-or-Redirect-Approach/)的方法。
+
+```properties
+Server_IP: example.com or your server ip
+Server_Port: 443
+Password: ifYouWantToKeepYourPassphraseSafeChangeThis!!
+Encryption: chacha20-ietf-poly1305
+Plugin_Program: pathToYourV2ray-plugin_windows_arch.exe
+Plugin_Options: mux=0;tls;mode=websocket;path=/path;host=example.com
+```
+
+### Shadowsocks Android plugin 关键部分示例如下
+
+> 需安装 shadowsocks 和 v2ray plugin，并搭配一同使用。
+> Concurrent connections 必须为 0，否则无法连接到服务器。
+
+```properties
+Plugin: v2ray
+Configuration:
+    Transport_mode: websocket-tls
+    Hostname: example.com
+    Path: /path
+    Concurrent_connections: 0
+    Certificate_for_TLS_verification: Not set
+```

--- a/V5-Shadowsocks-Websocket-Web-TLS/README.md
+++ b/V5-Shadowsocks-Websocket-Web-TLS/README.md
@@ -1,0 +1,38 @@
+# These settings are also compatible with Shadowsocks client + V2Ray-plugin
+
+> The complete setup also requires a web server to handle the TLS and proxy pass the deciphered request to the backend v2ray server listeing on 127.0.0.1:10000.
+> You can find the web server config examples at [https://guide.v2fly.org/en_US/advanced/wss_and_web.html#server-side-configuration](https://guide.v2fly.org/en_US/advanced/wss_and_web.html#server-side-configuration).
+
+中文用户请看[这里](./README-CN.md)。
+
+## Shadowsocks client configuration examples
+
+> You should change the following configurations according to your server configs.
+
+### Shadowsocks windows client configuration examples
+
+> `mux=0` is indispensable when connecting with V2Ray-plugin, if you wish to use mux you need to try the [Domainsocket or Redirect Approach](./Domainsocket-or-Redirect-Approach/).
+
+```properties
+Server_IP: example.com or your server IP
+Server_Port: 443
+Password: ifYouWantToKeepYourPassphraseSafeChangeThis!!
+Encryption: chacha20-ietf-poly1305
+Plugin_Program: pathToYourV2ray-plugin_windows_arch.exe
+Plugin_Options: mux=0;tls;mode=websocket;path=/path;host=example.com
+```
+
+### shadowsocks Android plugin configuration examples
+
+> Both the shadowsocks android and the V2Ray plugin android are mandatory, they are available on Google Play Store.\
+> _`Concurrent connections must be 0.`_
+
+```properties
+Plugin: v2ray
+Configuration:
+    Transport_mode: websocket-tls
+    Hostname: example.com
+    Path: /path
+    Concurrent_connections: 0
+    Certificate_for_TLS_verification: Not set
+```

--- a/V5-Shadowsocks-Websocket-Web-TLS/config_client.json
+++ b/V5-Shadowsocks-Websocket-Web-TLS/config_client.json
@@ -1,0 +1,49 @@
+{
+    "access": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "error": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "inbounds": [
+        {
+            "listen": "127.0.0.1",
+            "port": "10808",
+            "protocol": "socks",
+            "settings": {
+                "udpEnabled": true,
+                "address": "127.0.0.1"
+            }
+        },
+        {
+            "listen": "127.0.0.1",
+            "port": "10809",
+            "protocol": "http"
+        }
+    ],
+    "outbounds": [
+        {
+            "protocol": "shadowsocks",
+            "settings": {
+                "address": "{{ host }}",
+                "port": 443,
+                "method": "chacha20-ietf-poly1305",
+                "password": "{{ password }}"
+            },
+            "streamSettings": {
+                "transport": "ws",
+                "security": "tls",
+                "transportSettings": {
+                    "path": "/path"
+                }
+            },
+            "tag": "proxy"
+        },
+        {
+            "protocol": "freedom",
+            "tag": "direct"
+        }
+    ]
+}

--- a/V5-Shadowsocks-Websocket-Web-TLS/config_server.json
+++ b/V5-Shadowsocks-Websocket-Web-TLS/config_server.json
@@ -1,0 +1,37 @@
+{
+    "access": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "error": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "inbounds": [
+        {
+            "listen": "127.0.0.1",
+            "port": 10000,
+            "protocol": "shadowsocks",
+            "settings": {
+                "method": "chacha20-ietf-poly1305",
+                "password": "{{ password }}"
+            },
+            "streamSettings": {
+                "transport": "ws",
+                "transportSettings": {
+                    "path": "/path"
+                }
+            }
+        }
+    ],
+    "outbounds": [
+        {
+            "protocol": "freedom",
+            "tag": "direct"
+        },
+        {
+            "protocol": "blackhole",
+            "tag": "block"
+        }
+    ]
+}

--- a/V5-Shadowsocks-gRPC-Web-TLS/README-CN.md
+++ b/V5-Shadowsocks-gRPC-Web-TLS/README-CN.md
@@ -1,0 +1,26 @@
+# 最低版本要求
+
+NGINX 的最低版本要求为 1.13.10:\
+[https://www.nginx.com/blog/nginx-1-13-10-grpc/](https://www.nginx.com/blog/nginx-1-13-10-grpc/)。
+
+V2Ray-core 的最低版本要求为 v5.0.4:\
+[https://www.v2fly.org/config/transport/grpc.html#grpcobject](https://www.v2fly.org/config/transport/grpc.html#grpcobject)。
+
+## 本设置同样适用于 Shadowsocks 客户端搭配 V2Ray-plugin 使用
+
+_你需要一个兼容 gRPC 的 v2ray-plugin 程序。
+例如由[TeddySun](https://github.com/teddysun)维护的 v2ray-plugin 叉子: \
+[https://github.com/teddysun/v2ray-plugin](https://github.com/teddysun/v2ray-plugin)。_
+
+### 客户端设置
+
+Shadowsocks Windows 设置示例:
+
+```properties
+Server_IP: mydomain.me OR your server IP
+Server_Port: 443
+Password: ifYouWantToKeepYourPassphraseSafeChangeThis!!
+Encryption: chacha20-ietf-poly1305
+Plugin_Program: pathToYourV2ray-plugin_windows_arch.exe
+Plugin_Options: tls;mode=grpc;serviceName=michi;host=mydomain.me
+```

--- a/V5-Shadowsocks-gRPC-Web-TLS/README.md
+++ b/V5-Shadowsocks-gRPC-Web-TLS/README.md
@@ -1,0 +1,28 @@
+# Minimum Versions
+
+中文用户请看[这里](./README-CN.md)。
+
+Minimum NGINX version is 1.13.10:\
+[https://www.nginx.com/blog/nginx-1-13-10-grpc/](https://www.nginx.com/blog/nginx-1-13-10-grpc/).
+
+Minimum V2Ray-Core version is v5.0.4:\
+[https://www.v2fly.org/config/transport/grpc.html#grpcobject](https://www.v2fly.org/config/transport/grpc.html#grpcobject).
+
+## These settings are also compatible with shadowsocks + v2ray-plugins
+
+_You need a grpc compatible v2ray-plugin program to use with shadowsocks client.
+For example the one maintained by [TeddySun](https://github.com/teddysun): \
+[https://github.com/teddysun/v2ray-plugin](https://github.com/teddysun/v2ray-plugin)._
+
+### Client Configurations
+
+Shadowsocks Windows Example Config:
+
+```properties
+Server_IP: mydomain.me OR your server IP
+Server_Port: 443
+Password: ifYouWantToKeepYourPassphraseSafeChangeThis!!
+Encryption: chacha20-ietf-poly1305
+Plugin_Program: pathToYourV2ray-plugin_windows_arch.exe
+Plugin_Options: tls;mode=grpc;serviceName=michi;host=mydomain.me
+```

--- a/V5-Shadowsocks-gRPC-Web-TLS/config_client.json
+++ b/V5-Shadowsocks-gRPC-Web-TLS/config_client.json
@@ -1,0 +1,49 @@
+{
+    "access": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "error": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "inbounds": [
+        {
+            "listen": "127.0.0.1",
+            "port": "10808",
+            "protocol": "socks",
+            "settings": {
+                "udpEnabled": true,
+                "address ": "127.0.0.1"
+            }
+        },
+        {
+            "listen": "127.0.0.1",
+            "port": "10809",
+            "protocol": "http"
+        }
+    ],
+    "outbounds": [
+        {
+            "protocol": "shadowsocks",
+            "settings": {
+                "address": "{{ host }}",
+                "port": 443,
+                "method": "chacha20-ietf-poly1305",
+                "password": "{{ password }}"
+            },
+            "streamSettings": {
+                "transport": "grpc",
+                "security": "tls",
+                "transportSettings": {
+                    "serviceName": "michi"
+                }
+            },
+            "tag": "proxy"
+        },
+        {
+            "protocol": "freedom",
+            "tag": "direct"
+        }
+    ]
+}

--- a/V5-Shadowsocks-gRPC-Web-TLS/config_server.json
+++ b/V5-Shadowsocks-gRPC-Web-TLS/config_server.json
@@ -1,0 +1,37 @@
+{
+    "access": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "error": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "inbounds": [
+        {
+            "listen": "127.0.0.1",
+            "port": 12345,
+            "protocol": "shadowsocks",
+            "settings": {
+                "method": "chacha20-ietf-poly1305",
+                "password": "{{ password }}"
+            },
+            "streamSettings": {
+                "transport": "grpc",
+                "transportSettings": {
+                    "serviceName": "michi"
+                }
+            }
+        }
+    ],
+    "outbounds": [
+        {
+            "protocol": "freedom",
+            "tag": "direct"
+        },
+        {
+            "protocol": "blackhole",
+            "tag": "block"
+        }
+    ]
+}

--- a/V5-Shadowsocks-gRPC-Web-TLS/nginx_proxy.conf
+++ b/V5-Shadowsocks-gRPC-Web-TLS/nginx_proxy.conf
@@ -1,0 +1,32 @@
+server {
+  listen 443 ssl;
+  listen [::]:443 ssl;
+  
+  ssl_certificate       /etc/v2ray/v2ray.crt;
+  ssl_certificate_key   /etc/v2ray/v2ray.key;
+  ssl_session_timeout 1d;
+  ssl_session_cache shared:MozSSL:10m;
+  ssl_session_tickets off;
+  
+  ssl_protocols         TLSv1.2 TLSv1.3;
+  ssl_ciphers           ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+  ssl_prefer_server_ciphers off;
+  
+  server_name           mydomain.me;
+  location /michi/Tun { # This michi shall in consistent with the grpc serviceName in v2ray config.json
+  
+    if ($request_method != "POST") { # if the request method is not POST for this location, return 404
+        return 404;
+    }
+
+    grpc_socket_keepalive on;
+    grpc_intercept_errors on;
+    grpc_pass grpc://127.0.0.1:12345; # presume v2ray is listening on port 12345 
+    grpc_set_header Upgrade $http_upgrade;
+    grpc_set_header Connection "upgrade";
+    grpc_set_header Host $host;
+    # Show real IP in v2ray access.log
+    grpc_set_header X-Real-IP $remote_addr;
+    grpc_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  }
+}

--- a/V5-Socks5-TLS/README.md
+++ b/V5-Socks5-TLS/README.md
@@ -1,0 +1,76 @@
+## 关于 SOCKS5 over TLS 方案的安全提示
+
+该配置组合应仅供技术研究/参考使用，因为 **SOCKS5 over TLS 几乎不提供隐密性保证，可被简单地主动探测**。
+
+### 探测方式
+对任意未知 TLS 业务，若怀疑其为 SOCKS5/TLS 业务，审查者可向该端口建立一个 TLS 连接并在其上传送 SOCKS5 载荷。
+
+若该服务对 SOCKS5 请求做出响应，无论是否设置 SOCKS5 的鉴权机制，审查者均可通过回包内容一次准确判断该业务是否为 SOCKS5 / TLS。
+
+来自 [@studentmain](https://github.com/studentmain) 的两个典型样例对话：
+
+```
+-> 05 01 01
+<- 05 ff
+```
+
+```
+-> 05 02 00 02
+<- 05 00 / 05 02
+```
+
+### 参考资料
+[RFC1928](https://tools.ietf.org/html/rfc1928) 节录如下：
+```
+   The client connects to the server, and sends a version
+   identifier/method selection message:
+
+                   +----+----------+----------+
+                   |VER | NMETHODS | METHODS  |
+                   +----+----------+----------+
+                   | 1  |    1     | 1 to 255 |
+                   +----+----------+----------+
+
+   The VER field is set to X'05' for this version of the protocol.  The
+   NMETHODS field contains the number of method identifier octets that
+   appear in the METHODS field.
+
+   The server selects from one of the methods given in METHODS, and
+   sends a METHOD selection message:
+
+                         +----+--------+
+                         |VER | METHOD |
+                         +----+--------+
+                         | 1  |   1    |
+                         +----+--------+
+
+   If the selected METHOD is X'FF', none of the methods listed by the
+   client are acceptable, and the client MUST close the connection.
+
+   The values currently defined for METHOD are:
+
+          o  X'00' NO AUTHENTICATION REQUIRED
+          o  X'01' GSSAPI
+          o  X'02' USERNAME/PASSWORD
+          o  X'03' to X'7F' IANA ASSIGNED
+          o  X'80' to X'FE' RESERVED FOR PRIVATE METHODS
+          o  X'FF' NO ACCEPTABLE METHODS
+
+```
+
+[RFC1929](https://tools.ietf.org/html/rfc1929) 节录如下：
+
+```
+   The server verifies the supplied UNAME and PASSWD, and sends the
+   following response:
+
+                        +----+--------+
+                        |VER | STATUS |
+                        +----+--------+
+                        | 1  |   1    |
+                        +----+--------+
+
+   A STATUS field of X'00' indicates success. If the server returns a
+   `failure' (STATUS value other than X'00') status, it MUST close the
+   connection.
+```

--- a/V5-Socks5-TLS/config_client.json
+++ b/V5-Socks5-TLS/config_client.json
@@ -1,0 +1,47 @@
+{
+    "access": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "error": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "inbounds": [
+        {
+            "listen": "127.0.0.1",
+            "port": "10808",
+            "protocol": "socks",
+            "settings": {
+                "udpEnabled": true,
+                "address": "127.0.0.1"
+            }
+        },
+        {
+            "listen": "127.0.0.1",
+            "port": "10809",
+            "protocol": "http"
+        }
+    ],
+    "outbounds": [
+        {
+            "protocol": "socks",
+            "settings": {
+                "address": "",
+                "port": 1234
+            },
+            "streamSettings": {
+                "transport": "tcp",
+                "security": "tls",
+                "securitySettings": {
+                    "serverName": "example.domain"
+                }
+            },
+            "tag": "proxy"
+        },
+        {
+            "protocol": "freedom",
+            "tag": "direct"
+        }
+    ]
+}

--- a/V5-Socks5-TLS/config_server.json
+++ b/V5-Socks5-TLS/config_server.json
@@ -1,0 +1,43 @@
+{
+    "access": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "error": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "inbounds": [
+        {
+            "listen": "0.0.0.0",
+            "port": 1234,
+            "protocol": "socks",
+            "settings": {
+                "udpEnabled": true,
+                "address": "127.0.0.1"
+            },
+            "streamSettings": {
+                "transport": "tcp",
+                "security": "tls",
+                "securitySettings": {
+                    "certificate": [
+                        {
+                            "certificateFile": "/path/to/certificate.crt",
+                            "keyFile": "/path/to/key.key"
+                        }
+                    ]
+                }
+            }
+        }
+    ],
+    "outbounds": [
+        {
+            "protocol": "freedom",
+            "tag": "direct"
+        },
+        {
+            "protocol": "blackhole",
+            "tag": "block"
+        }
+    ]
+}

--- a/V5-Trojan-TCP-TLS (minimal)/config_client.json
+++ b/V5-Trojan-TCP-TLS (minimal)/config_client.json
@@ -1,0 +1,34 @@
+{
+    "access": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "error": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "inbounds": [
+        {
+            "port": 10800,
+            "address": "127.0.0.1",
+            "protocol": "socks",
+            "settings": {
+                "udpEnabled": true
+            }
+        }
+    ],
+    "outbounds": [
+        {
+            "protocol": "trojan",
+            "settings": {
+                "address": "example.com",
+                "port": 443,
+                "password": "your password"
+            },
+            "streamSettings": {
+                "transport": "tcp",
+                "security": "tls"
+            }
+        }
+    ]
+}

--- a/V5-Trojan-TCP-TLS (minimal)/config_server.json
+++ b/V5-Trojan-TCP-TLS (minimal)/config_server.json
@@ -1,0 +1,42 @@
+{
+    "access": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "error": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "inbounds": [
+        {
+            "port": 443,
+            "protocol": "trojan",
+            "settings": {
+                "users": [
+                    "your password1",
+                    "your password2"
+                ]
+            },
+            "streamSettings": {
+                "transport": "tcp",
+                "security": "tls",
+                "securitySettings": {
+                    "nextProtocol": [
+                        "http/1.1"
+                    ],
+                    "certificate": [
+                        {
+                            "certificateFile": "/path/to/fullchain.crt",
+                            "keyFile": "/path/to/private.key"
+                        }
+                    ]
+                }
+            }
+        }
+    ],
+    "outbounds": [
+        {
+            "protocol": "freedom"
+        }
+    ]
+}

--- a/V5-VLESS-H2C-Caddy2/Caddyfile
+++ b/V5-VLESS-H2C-Caddy2/Caddyfile
@@ -1,0 +1,10 @@
+xx.com {
+    root * /var/www
+    file_server
+    
+    reverse_proxy /path 127.0.0.1:2001 {
+        transport http {
+            versions h2c
+        }
+    }
+}

--- a/V5-VLESS-H2C-Caddy2/README.md
+++ b/V5-VLESS-H2C-Caddy2/README.md
@@ -1,0 +1,5 @@
+# 原理图：
+v2ray client <--- H2 ---> caddy2 <--- H2C ---> v2ray server
+
+注意：
+目前仅 caddy2 的 v2.2.0-rc.1 版及以后完美支持 v2ray 的 H2C,实现 H2(HTTP/2)应用。

--- a/V5-VLESS-H2C-Caddy2/client.json
+++ b/V5-VLESS-H2C-Caddy2/client.json
@@ -1,0 +1,53 @@
+{
+    "access": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "error": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "inbounds": [
+        {
+            "port": "10808",
+            "protocol": "socks",
+            "settings": {
+                "udpEnabled": true
+            }
+        },
+        {
+            "port": "10809",
+            "protocol": "http"
+        }
+    ],
+    "outbounds": [
+        {
+            "protocol": "vless",
+            "settings": {
+                "address": "xx.com",
+                "port": 443,
+                "uuid": "your UUID"
+            },
+            "streamSettings": {
+                "transport": "h2",
+                "security": "tls",
+                "transportSettings": {
+                    "host": [
+                        "xx.com"
+                    ],
+                    "path": "/path"
+                }
+            }
+        },
+        {
+            "tag": "direct",
+            "protocol": "freedom",
+            "settings": {}
+        },
+        {
+            "tag": "blocked",
+            "protocol": "blackhole",
+            "settings": {}
+        }
+    ]
+}

--- a/V5-VLESS-H2C-Caddy2/server.json
+++ b/V5-VLESS-H2C-Caddy2/server.json
@@ -1,0 +1,45 @@
+{
+    "access": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "error": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "inbounds": [
+        {
+            "port": 2001,
+            "listen": "127.0.0.1",
+            "protocol": "vless",
+            "settings": {
+                "users": [
+                    "UUID1",
+                    "UUID2"
+                ]
+            },
+            "streamSettings": {
+                "security": "none",
+                "transport": "h2",
+                "transportSettings": {
+                    "path": "/path",
+                    "host": [
+                        "xx.com"
+                    ]
+                }
+            }
+        }
+    ],
+    "outbounds": [
+        {
+            "tag": "direct",
+            "protocol": "freedom",
+            "settings": {}
+        },
+        {
+            "tag": "blocked",
+            "protocol": "blackhole",
+            "settings": {}
+        }
+    ]
+}

--- a/V5-VLESS-gRPC-TLS/config_client.json
+++ b/V5-VLESS-gRPC-TLS/config_client.json
@@ -1,0 +1,45 @@
+{
+    "access": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "error": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "inbounds": [
+        {
+            "listen": "127.0.0.1",
+            "port": "10808",
+            "protocol": "socks"
+        },
+        {
+            "listen": "127.0.0.1",
+            "port": "10809",
+            "protocol": "http"
+        }
+    ],
+    "outbounds": [
+        {
+            "protocol": "vless",
+            "settings": {
+                "address": "your_server_ip",
+                "port": 443,
+                "uuid": "your UUID"
+            },
+            "streamSettings": {
+                "transport": "gun",
+                "security": "tls",
+                "securitySettings": {
+                    "serverName": "your_domain",
+                    "nextProtocol": [
+                        "h2"
+                    ]
+                },
+                "transportSettings": {
+                    "serviceName": "GunService"
+                }
+            }
+        }
+    ]
+}

--- a/V5-VLESS-gRPC-TLS/config_server.json
+++ b/V5-VLESS-gRPC-TLS/config_server.json
@@ -1,0 +1,48 @@
+{
+    "access": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "error": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "inbounds": [
+        {
+            "listen": "0.0.0.0",
+            "port": 443,
+            "protocol": "vless",
+            "settings": {
+                "users ": [
+                    "UUID1",
+                    "UUID2"
+                ]
+            },
+            "streamSettings": {
+                "transport": "gun",
+                "security": "tls",
+                "securitySettings": {
+                    "serverName": "your_domain",
+                    "nextProtocol": [
+                        "h2"
+                    ],
+                    "certificate": [
+                        {
+                            "certificateFile": "/path/to/fullchain.crt",
+                            "keyFile": "/path/to/private.key"
+                        }
+                    ]
+                },
+                "transportSettings": {
+                    "serviceName": "GunService"
+                }
+            }
+        }
+    ],
+    "outbounds": [
+        {
+            "protocol": "freedom",
+            "tag": "direct"
+        }
+    ]
+}

--- a/V5-VLESS-mKCPSeed/config_client.json
+++ b/V5-VLESS-mKCPSeed/config_client.json
@@ -1,0 +1,41 @@
+{
+    "access": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "error": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "inbounds": [
+        {
+            "port": 10808,
+            "listen": "127.0.0.1",
+            "protocol": "socks",
+            "settings": {
+                "udpEnabled": true
+            }
+        },
+        {
+            "port": 10809,
+            "listen": "127.0.0.1",
+            "protocol": "http"
+        }
+    ],
+    "outbounds": [
+        {
+            "protocol": "vless",
+            "settings": {
+                "address": "{{ host }}",
+                "port": "{{ port }}",
+                "uuid": "your UUID"
+            },
+            "streamSettings": {
+                "transport": "kcp",
+                "transportSettings": {
+                    "seed": "{{ seed }}"
+                }
+            }
+        }
+    ]
+}

--- a/V5-VLESS-mKCPSeed/config_server.json
+++ b/V5-VLESS-mKCPSeed/config_server.json
@@ -1,0 +1,33 @@
+{
+    "access": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "error": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "inbounds": [
+        {
+            "protocol": "vless",
+            "port": "{{ port }}",
+            "settings": {
+                "users": [
+                    "UUID1",
+                    "UUID2"
+                ]
+            },
+            "streamSettings": {
+                "transport": "kcp",
+                "transportSettings": {
+                    "seed": "{{ seed }}"
+                }
+            }
+        }
+    ],
+    "outbounds": [
+        {
+            "protocol": "freedom"
+        }
+    ]
+}

--- a/V5-VMess-HTTP2/config_client.json
+++ b/V5-VMess-HTTP2/config_client.json
@@ -1,0 +1,45 @@
+{
+    "access": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "error": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "inbounds": [
+        {
+            "listen": "127.0.0.1",
+            "port": "10808",
+            "protocol": "socks",
+            "settings": {
+                "udpEnabled": true,
+                "address": "127.0.0.1"
+            }
+        },
+        {
+            "listen": "127.0.0.1",
+            "port": "10809",
+            "protocol": "http"
+        }
+    ],
+    "outbounds": [
+        {
+            "protocol": "vmess",
+            "settings": {
+                "address": "",
+                "port": 1234,
+                "uuid": "your UUID"
+            },
+            "streamSettings": {
+                "transport": "http",
+                "security": "tls"
+            },
+            "tag": "proxy"
+        },
+        {
+            "protocol": "freedom",
+            "tag": "direct"
+        }
+    ]
+}

--- a/V5-VMess-HTTP2/config_server.json
+++ b/V5-VMess-HTTP2/config_server.json
@@ -1,0 +1,45 @@
+{
+    "access": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "error": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "inbounds": [
+        {
+            "listen": "0.0.0.0",
+            "port": 1234,
+            "protocol": "vmess",
+            "settings": {
+                "users": [
+                    "UUID1",
+                    "UUID2"
+                ]
+            },
+            "streamSettings": {
+                "transport": "http",
+                "security": "tls",
+                "securitySettings": {
+                    "certificate": [
+                        {
+                            "certificateFile": "/path/to/certificate.crt",
+                            "keyFile": "/path/to/key.key"
+                        }
+                    ]
+                }
+            }
+        }
+    ],
+    "outbounds": [
+        {
+            "protocol": "freedom",
+            "tag": "direct"
+        },
+        {
+            "protocol": "blackhole",
+            "tag": "block"
+        }
+    ]
+}

--- a/V5-VMess-TCP-TLS/config_client.json
+++ b/V5-VMess-TCP-TLS/config_client.json
@@ -1,0 +1,45 @@
+{
+    "access": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "error": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "inbounds": [
+        {
+            "listen": "127.0.0.1",
+            "port": "10808",
+            "protocol": "socks",
+            "settings": {
+                "udpEnabled": true,
+                "address": "127.0.0.1"
+            }
+        },
+        {
+            "listen": "127.0.0.1",
+            "port": "10809",
+            "protocol": "http"
+        }
+    ],
+    "outbounds": [
+        {
+            "protocol": "vmess",
+            "settings": {
+                "address": "",
+                "port": 1234,
+                "uuid": "your UUID"
+            },
+            "streamSettings": {
+                "transport": "tcp",
+                "security": "tls"
+            },
+            "tag": "proxy"
+        },
+        {
+            "protocol": "freedom",
+            "tag": "direct"
+        }
+    ]
+}

--- a/V5-VMess-TCP-TLS/config_server.json
+++ b/V5-VMess-TCP-TLS/config_server.json
@@ -1,0 +1,45 @@
+{
+    "access": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "error": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "inbounds": [
+        {
+            "listen": "0.0.0.0",
+            "port": 1234,
+            "protocol": "vmess",
+            "settings": {
+                "users": [
+                    "UUID1",
+                    "UUID2"
+                ]
+            },
+            "streamSettings": {
+                "transport": "tcp",
+                "security": "tls",
+                "securitySettings": {
+                    "certificate": [
+                        {
+                            "certificateFile": "/path/to/certificate.crt",
+                            "keyFile": "/path/to/key.key"
+                        }
+                    ]
+                }
+            }
+        }
+    ],
+    "outbounds": [
+        {
+            "protocol": "freedom",
+            "tag": "direct"
+        },
+        {
+            "protocol": "blackhole",
+            "tag": "block"
+        }
+    ]
+}

--- a/V5-VMess-TCP/config_client.json
+++ b/V5-VMess-TCP/config_client.json
@@ -1,0 +1,44 @@
+{
+    "access": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "error": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "inbounds": [
+        {
+            "listen": "127.0.0.1",
+            "port": "10808",
+            "protocol": "socks",
+            "settings": {
+                "udpEnabled": true,
+                "address": "127.0.0.1"
+            }
+        },
+        {
+            "listen": "127.0.0.1",
+            "port": "10809",
+            "protocol": "http"
+        }
+    ],
+    "outbounds": [
+        {
+            "protocol": "vmess",
+            "settings": {
+                "address": "",
+                "port": 1234,
+                "uuid": "your UUID"
+            },
+            "streamSettings": {
+                "transport": "tcp"
+            },
+            "tag": "proxy"
+        },
+        {
+            "protocol": "freedom",
+            "tag": "direct"
+        }
+    ]
+}

--- a/V5-VMess-TCP/config_server.json
+++ b/V5-VMess-TCP/config_server.json
@@ -1,0 +1,36 @@
+{
+    "access": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "error": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "inbounds": [
+        {
+            "listen": "0.0.0.0",
+            "port": 1234,
+            "protocol": "vmess",
+            "settings": {
+                "users": [
+                    "UUID1",
+                    "UUID2"
+                ]
+            },
+            "streamSettings": {
+                "transport": "tcp"
+            }
+        }
+    ],
+    "outbounds": [
+        {
+            "protocol": "freedom",
+            "tag": "direct"
+        },
+        {
+            "protocol": "blackhole",
+            "tag": "block"
+        }
+    ]
+}

--- a/V5-VMess-Websocket-TLS/config_client.json
+++ b/V5-VMess-Websocket-TLS/config_client.json
@@ -1,0 +1,45 @@
+{
+    "access": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "error": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "inbounds": [
+        {
+            "listen": "127.0.0.1",
+            "port": "10808",
+            "protocol": "socks",
+            "settings": {
+                "udpEnabled": true,
+                "address": "127.0.0.1"
+            }
+        },
+        {
+            "listen": "127.0.0.1",
+            "port": "10809",
+            "protocol": "http"
+        }
+    ],
+    "outbounds": [
+        {
+            "protocol": "vmess",
+            "settings": {
+                "address": "",
+                "port": 1234,
+                "uuid": "your UUID"
+            },
+            "streamSettings": {
+                "transport": "ws",
+                "security": "tls"
+            },
+            "tag": "proxy"
+        },
+        {
+            "protocol": "freedom",
+            "tag": "direct"
+        }
+    ]
+}

--- a/V5-VMess-Websocket-TLS/config_server.json
+++ b/V5-VMess-Websocket-TLS/config_server.json
@@ -1,0 +1,45 @@
+{
+    "access": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "error": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "inbounds": [
+        {
+            "listen": "0.0.0.0",
+            "port": 1234,
+            "protocol": "vmess",
+            "settings": {
+                "users": [
+                    "UUID1",
+                    "UUID2"
+                ]
+            },
+            "streamSettings": {
+                "transport": "ws",
+                "security": "tls",
+                "securitySettings": {
+                    "certificate": [
+                        {
+                            "certificateFile": "/path/to/certificate.crt",
+                            "keyFile": "/path/to/key.key"
+                        }
+                    ]
+                }
+            }
+        }
+    ],
+    "outbounds": [
+        {
+            "protocol": "freedom",
+            "tag": "direct"
+        },
+        {
+            "protocol": "blackhole",
+            "tag": "block"
+        }
+    ]
+}

--- a/V5-VMess-Websocket/config_client.json
+++ b/V5-VMess-Websocket/config_client.json
@@ -1,0 +1,44 @@
+{
+    "access": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "error": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "inbounds": [
+        {
+            "listen": "127.0.0.1",
+            "port": "10808",
+            "protocol": "socks",
+            "settings": {
+                "udpEnabled": true,
+                "address": "127.0.0.1"
+            }
+        },
+        {
+            "listen": "127.0.0.1",
+            "port": "10809",
+            "protocol": "http"
+        }
+    ],
+    "outbounds": [
+        {
+            "protocol": "vmess",
+            "settings": {
+                "address": "",
+                "port": 1234,
+                "uuid": "your UUID"
+            },
+            "streamSettings": {
+                "transport": "ws"
+            },
+            "tag": "proxy"
+        },
+        {
+            "protocol": "freedom",
+            "tag": "direct"
+        }
+    ]
+}

--- a/V5-VMess-Websocket/config_server.json
+++ b/V5-VMess-Websocket/config_server.json
@@ -1,0 +1,37 @@
+{
+    "access": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "error": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "inbounds": [
+        {
+            "listen": "0.0.0.0",
+            "port": 1234,
+            "protocol": "vmess",
+            "settings": {
+                "users": [
+                    "UUID1",
+                    "UUID2"
+                ]
+            },
+            "streamSettings": {
+                "transport": "ws",
+                "security": "none"
+            }
+        }
+    ],
+    "outbounds": [
+        {
+            "protocol": "freedom",
+            "tag": "direct"
+        },
+        {
+            "protocol": "blackhole",
+            "tag": "block"
+        }
+    ]
+}

--- a/V5-VMess-mKCPSeed/config_client.json
+++ b/V5-VMess-mKCPSeed/config_client.json
@@ -1,0 +1,41 @@
+{
+    "access": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "error": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "inbounds": [
+        {
+            "port": 10808,
+            "listen": "127.0.0.1",
+            "protocol": "socks",
+            "settings": {
+                "udpEnabled": true
+            }
+        },
+        {
+            "port": 10809,
+            "listen": "127.0.0.1",
+            "protocol": "http"
+        }
+    ],
+    "outbounds": [
+        {
+            "protocol": "vmess",
+            "settings": {
+                "address": "{{ host }}",
+                "port": "{{ port }}",
+                "uuid": "your UUID"
+            },
+            "streamSettings": {
+                "transport": "kcp",
+                "transportSettings": {
+                    "seed": "{{ seed }}"
+                }
+            }
+        }
+    ]
+}

--- a/V5-VMess-mKCPSeed/config_server.json
+++ b/V5-VMess-mKCPSeed/config_server.json
@@ -1,0 +1,32 @@
+{
+    "access": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "error": {
+        "type": "Console",
+        "level": "Warning"
+    },
+    "inbounds": [
+        {
+            "protocol": "vmess",
+            "settings": {
+                "users": [
+                    "UUID1",
+                    "UUID2"
+                ]
+            },
+            "streamSettings": {
+                "transport": "kcp",
+                "transportSettings": {
+                    "seed": "{{ seed }}"
+                }
+            }
+        }
+    ],
+    "outbounds": [
+        {
+            "protocol": "freedom"
+        }
+    ]
+}


### PR DESCRIPTION
代理协议的vless的fallback文档不全, VLESS-TCP,VLESS-TCP-TLS, VLESS-TCP-TLS (maximal by rprx), VLESS-TCP-TLS (minimal by rprx), VLESS-TCP-TLS-proxy protocol和VLESS-TCP-TLS-WS (recommended)未写
传输流协议的tcp的header文档不全,VMess-HTTP未写